### PR TITLE
Add Cloudformation file for deploying state machine with simple pipeline

### DIFF
--- a/cloudformation-states.yaml
+++ b/cloudformation-states.yaml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Set up an executable pipeline state machine
+
+Parameters:
+  Environment:
+    Type: String
+    Default: staging
+    AllowedValues:
+      - staging
+      - production
+    Description: The environment for which the cluster need to be created.
+  ExperimentId:
+    Default: '6379'
+    Type: String
+    Description: The ID of the experiment the system is created for.
+
+Resources:
+  PipelineStateMachine:
+    Type: "AWS::StepFunctions::StateMachine"
+    Properties:
+      DefinitionString:
+        !Sub
+          - |-
+            {
+              "Comment": "N/A",
+              "StartAt": "DeleteCompletedJobs",
+              "States": {
+                "DeleteCompletedJobs": {
+                  "Type": "Task",
+                  "Comment": "Deletes all the preivous server jobs that are already completed.",
+                  "Resource": "arn:aws:states:::eks:call",
+                  "Parameters": {
+                    "ClusterName": "biomage-${Environment}",
+                    "CertificateAuthority.$": "$.certificateAuthority",
+                    "Endpoint": "${Endpoint}",
+                    "Method": "DELETE",
+                    "Path": "/apis/batch/v1/namespaces/default/jobs",
+                    "QueryParameters": {
+                      "fieldSelector": [
+                        "status.successful=1"
+                      ]
+                    }
+                  },
+                  "Next": "LaunchKubernetesJobIfNotExists"
+                },
+                "LaunchKubernetesJobIfNotExists": {
+                  "Type": "Task",
+                  "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+                  "Resource": "arn:aws:states:::eks:call",
+                  "Parameters": {
+                    "ClusterName": "biomage-${Environment}",
+                    "CertificateAuthority.$": "$.certificateAuthority",
+                    "Endpoint": "${Endpoint}",
+                    "Method": "POST",
+                    "Path": "/apis/batch/v1/namespaces/default/jobs",
+                    "RequestBody": {
+                      "apiVersion": "batch/v1",
+                      "kind": "Job",
+                      "metadata": {
+                        "name": "remoter-server-${ExperimentId}"
+                      },
+                      "spec": {
+                        "template": {
+                          "metadata": {
+                            "name": "remoter-server-${ExperimentId}"
+                          },
+                          "spec": {
+                            "containers": [
+                              {
+                                "name": "remoter-server",
+                                "image": "242905224710.dkr.ecr.eu-west-1.amazonaws.com/pipeline:refs-heads-master-236bab58afda4a763bc6a72514247e228fae5c75-remoter-server"
+                              }
+                            ],
+                            "restartPolicy": "Never"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "Retry": [
+                    {
+                      "ErrorEquals": [ "EKS.409" ],
+                      "IntervalSeconds": 1,
+                      "BackoffRate": 2.0,
+                      "MaxAttempts": 2
+                    }
+                  ],
+                  "Catch": [
+                    {
+                      "ErrorEquals": [ "EKS.409" ],
+                      "ResultPath": "$.error-info",
+                      "Next": "Wait"
+                    }
+                  ],
+                  "Next": "Wait"
+                },
+                "Wait": {
+                  "Type": "Wait",
+                  "Seconds": 5,
+                  "End": true
+                }
+              }
+            }
+          - Endpoint:
+              Fn::ImportValue:
+                !Sub "eksctl-biomage-${Environment}-cluster::Endpoint"
+              
+      RoleArn:
+        Fn::ImportValue:
+          !Sub "biomage-state-machine-role-${Environment}::ARN"


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-507

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
A CloudFormation file can deploy a state machine that can call into the Kubernetes cluster.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
