### PR TITLE
Fix host.docker.internal override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Biomage Pipeline
+
 The Cellscope pipeline project for dependency-managed work processing.
 
-Getting started
----------------
+## Getting started
 
 The steps of the pipeline that are run through this project are started
 spontaneously on your machine as Docker containers, simulating Kubernetes
@@ -50,9 +50,6 @@ using the special address `host.docker.internal`. This is not recognised by Dock
 can be overriden by the environment variable `DOCKER_GATEWAY_HOST`:
 
 ```bash
-$ EXPORT DOCKER_GATEWAY_HOST=`docker network inspect --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}'
-$ npm start
-``` 
-
-**TODO**: Another OSX/Linux incompatibility is related to the aws development configuration, where OSX expects
-an url while Linux expects a host name.
+EXPORT DOCKER_GATEWAY_HOST=`docker network inspect --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}'
+npm start
+```

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ using the special address `host.docker.internal`. This is not recognised by Dock
 can be overriden by the environment variable `DOCKER_GATEWAY_HOST`:
 
 ```bash
-$ DOCKER_GATEWAY_HOST="`hostname -I` |awk '{print $1}'`" npm start
-```
+$ EXPORT DOCKER_GATEWAY_HOST=`docker network inspect --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}'
+$ npm start
+``` 
 
 **TODO**: Another OSX/Linux incompatibility is related to the aws development configuration, where OSX expects
 an url while Linux expects a host name.

--- a/remoter-client/src/init.r
+++ b/remoter-client/src/init.r
@@ -9,7 +9,7 @@ message("Got request with ID", run_id, "...")
 message(request)
 message("")
 parsed = RJSONIO::fromJSON(request)
-if (parsed$server == "DOCKER_GATEWAY_HOST") {
+if (parsed$server == "host.docker.internal") {
     parsed$server = Sys.getenv("DOCKER_GATEWAY_HOST")
     if (parsed$server == "") {
         parsed$server = "host.docker.internal"


### PR DESCRIPTION
# Background
#### Link to issue 

N/A

#### Link to staging deployment URL 

N/A

#### Links to any Pull Requests related to this

N/A

#### Anything else the reviewers should know about the changes here

Fixes a broken attempt to provide a way to run the pipeline in Linux.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![capybara](https://user-images.githubusercontent.com/460418/111685457-3ab5e280-8828-11eb-9688-728b38d5ae11.JPG)
