### PR TITLE
Small fix for pipeline namespaces

### DIFF
--- a/remoter-client/src/wrapper.r
+++ b/remoter-client/src/wrapper.r
@@ -59,28 +59,28 @@ reload_from_s3 <- function(pipeline_config, experiment_id) {
 run_step <- function(task_name, scdata, config) {
     switch(task_name,
         test_fn = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         cellSizeDistribution = {
-            import::from("/src/cellSizeDistribution.r", task)
+            import::here("/src/cellSizeDistribution.r", task)
         },
         mitochondrialContent = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         classifier = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         numGenesVsNumUmis = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         doubletScores = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         dataIntegration = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         configureEmbedding = {
-            import::from("/src/test_fn.r", task)
+            import::here("/src/test_fn.r", task)
         },
         stop(paste("Invalid task name given:", task_name))
     )


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

Quick fix to the "Cannot assign name to different value in the given environment. Name already in use" error that didn't allow the rest of the pipeline to run. 

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
