### PR TITLE
Add cleanup operator to pipeline repository

### DIFF
--- a/chart-infra/templates/kube-cleanup-operator-deployment.yaml
+++ b/chart-infra/templates/kube-cleanup-operator-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: cleanup-operator
+    sandboxId: "{{ .Values.sandboxId }}"
+  name: cleanup-operator
+  namespace: {{.Release.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: cleanup-operator
+      sandboxId: "{{ .Values.sandboxId }}"
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        run: cleanup-operator
+        sandboxId: "{{ .Values.sandboxId }}"
+    spec:
+      serviceAccountName: cleanup-operator
+      containers:
+      - args:
+        - --namespace={{.Release.Namespace}}
+        - -delete-successful-after=30m
+        - -delete-failed-after=30m
+        image: quay.io/lwolf/kube-cleanup-operator
+        imagePullPolicy: Always
+        name: cleanup-operator
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 50m
+            memory: 50Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cleanup-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cleanup-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups: ["batch", "extensions"]
+  resources:
+  - jobs
+  verbs:
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cleanup-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cleanup-operator
+subjects:
+- kind: ServiceAccount
+  name: cleanup-operator


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-731

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
As said in the ticket, a straight up copy-paste from [here](https://github.com/biomage-ltd/worker/blob/master/chart-infra/templates/kube-cleanup-operator-deployment.yaml) in the `worker` repository, with the TTL value being modified to 30 minutes.

# Changes
### Code changes
Added a deployment to the `pipeline` repository that will delete completed jobs after 30 minutes. This is enough time for AWS to find the job to be complete (the AWS polling rate can be in the extreme once every 10 minutes), but does not leave crap behind.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
