### PR TITLE
Fix grey color on samples embedding

### DIFF
--- a/remoter-server/src/cellSizeDistribution.r
+++ b/remoter-server/src/cellSizeDistribution.r
@@ -109,6 +109,8 @@ task <- function(seurat_obj, config, task_name, sample_id) {
         barcodes_to_keep <- union(barcode_names_non_sample, barcode_names_keep_current_sample)
         
         seurat_obj.filtered <- subset_safe(seurat_obj,barcodes_to_keep)
+    }else{
+        seurat_obj.filtered <- seurat_obj
     }
 
     print(paste0("Cells per sample after filter for sample ", sample_id))

--- a/remoter-server/src/configureEmbedding.r
+++ b/remoter-server/src/configureEmbedding.r
@@ -221,11 +221,10 @@ coloring_samples_and_cluster <- function(scdata){
     ##########################
     # Coloring samples
     ###########################
-    remaining.colors <- color_pool[-c(1:length(unique(scdata@meta.data$color_active_ident)))]
     if ("type"%in%colnames(scdata@meta.data)) # In that case we are in multisample experiment
-        scdata@meta.data[, "color_samples"] <- remaining.colors[as.numeric(as.factor(scdata$type))]
+        scdata@meta.data[, "color_samples"] <- color_pool[as.numeric(as.factor(scdata$type))]
     else
-        scdata@meta.data[, "color_samples"] <- remaining.colors[1]
+        scdata@meta.data[, "color_samples"] <- color_pool[1]
 
     return(scdata)
 }

--- a/remoter-server/src/configureEmbedding.r
+++ b/remoter-server/src/configureEmbedding.r
@@ -205,7 +205,7 @@ coloring_samples_and_cluster <- function(scdata){
         color_pool <- scdata@misc[['color_pool']]
     }else{ # THIS SHOULD BE REMOVE ONCE THE EXPERIMENT HAS BEEN UPDATED WITH THE NEW VERSION OF THE DATA-INGEST 
         color_pool <- c("#e377c2","#8c564b","#d62728","#2ca02c","#ff7f0e","#1f77b4","#f8e71c","#3957ff","#d3fe14",
-        "#c9080a","#fec7f8","#0b7b3e","#0bf0e9","#c203c8","#fd9b39","#888593","#906407","#98ba7f","#fe6794","#10b0ff",
+        "#c9080a","#fec7f8","#0b7b3e","#0bf0e9","#c203c8","#fd9b39","#906407","#98ba7f","#fe6794","#10b0ff",
         "#ac7bff","#fee7c0","#964c63","#1da49c","#0ad811","#bbd9fd","#fe6cfe","#297192","#d1a09c","#78579e","#81ffad",
         "#739400","#ca6949","#d9bf01","#646a58","#d5097e","#bb73a9","#ccf6e9","#9cb4b6","#b6a7d4","#9e8c62","#6e83c8",
         "#01af64","#a71afd","#cfe589","#d4ccd1","#fd4109","#bf8f0e","#2f786e","#4ed1a5","#d8bb7d","#a54509","#6a9276",
@@ -221,10 +221,11 @@ coloring_samples_and_cluster <- function(scdata){
     ##########################
     # Coloring samples
     ###########################
+    remaining.colors <- color_pool[-c(1:length(unique(scdata@meta.data$color_active_ident)))]
     if ("type"%in%colnames(scdata@meta.data)) # In that case we are in multisample experiment
-        scdata@meta.data[, "color_samples"] <- color_pool[as.numeric(as.factor(scdata$type))]
+        scdata@meta.data[, "color_samples"] <- remaining.colors[as.numeric(as.factor(scdata$type))]
     else
-        scdata@meta.data[, "color_samples"] <- color_pool[1]
+        scdata@meta.data[, "color_samples"] <- remaining.colors[1]
 
     return(scdata)
 }


### PR DESCRIPTION
# Background
#### Link to issue 

There wasn't a ticket for this one, I just thought I'd fix the grey colors on the embedding by sample. It was unnecessary not to repeat the colors used in the embedding by clusters so I removed that bit of code and now the grey color is not being used.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
