### PR TITLE
adding FindVariableFeatures code to calc gene dispersion

### DIFF
--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -115,6 +115,13 @@ run_dataIntegration <- function(scdata, config){
         scdata <-Seurat::FindVariableFeatures(scdata, selection.method = "vst", nfeatures = nfeatures, verbose = F)
     }
 
+    scdata <- FindVariableFeatures(scdata, selection.method = "vst", assay = "RNA", nfeatures = nfeatures, verbose = FALSE)
+    vars <- HVFInfo(object = scdata, assay = "RNA", selection.method = 'vst') # to create vars
+    annotations <- scdata@misc[["gene_annotations"]]
+    vars$SYMBOL <- annotations$name[match(rownames(vars), annotations$input)]
+    vars$ENSEMBL <- rownames(vars)
+    scdata@misc[["gene_dispersion"]] <- vars
+
     # Scale in order to compute PCA
     scdata <- Seurat::ScaleData(scdata, verbose = F)
 

--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -110,7 +110,11 @@ run_dataIntegration <- function(scdata, config){
             data.split[[i]] <- Seurat::FindVariableFeatures(data.split[[i]], selection.method = "vst", nfeatures = nfeatures, verbose = FALSE)
         }
         data.anchors <- Seurat::FindIntegrationAnchors(object.list = data.split, dims = 1:numPCs, verbose = FALSE)
+
+        # @misc slots not preserved so transfer
+        misc <- scdata@misc
         scdata <- Seurat::IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
+        scdata@misc <- misc
         Seurat::DefaultAssay(scdata) <- "integrated"
     }else{
         # Else, we are in unisample experiment and we only need to normalize 

--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -100,7 +100,7 @@ run_dataIntegration <- function(scdata, config){
     # temporary to make sure we don't run integration if unisample
     nsamples <- length(unique(scdata$samples))
     
-    # Currently, we only support Seurat V3 pipeline for the multisample integration
+    # Currently, we only support Seurat V4 pipeline for the multisample integration
     if(nsamples > 1 && method=="seuratv4"){
         #FIX FOR CURRENT DATASET!!!!!!
         Seurat::DefaultAssay(scdata) <- "RNA"
@@ -119,7 +119,6 @@ run_dataIntegration <- function(scdata, config){
     }else{
         # Else, we are in unisample experiment and we only need to normalize 
         scdata <- Seurat::NormalizeData(scdata, normalization.method = normalization, verbose = F)
-        scdata <-Seurat::FindVariableFeatures(scdata, selection.method = "vst", nfeatures = nfeatures, verbose = F)
     }
 
     scdata <- FindVariableFeatures(scdata, selection.method = "vst", assay = "RNA", nfeatures = nfeatures, verbose = FALSE)

--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -97,8 +97,11 @@ run_dataIntegration <- function(scdata, config){
     umap_min_distance <- 0.3
     umap_distance_metric <- "euclidean"
 
+    # temporary to make sure we don't run integration if unisample
+    nsamples <- length(unique(scdata$samples))
+    
     # Currently, we only support Seurat V3 pipeline for the multisample integration
-   if(method=="seuratv4"){
+    if(nsamples > 1 && method=="seuratv4"){
         #FIX FOR CURRENT DATASET!!!!!!
         Seurat::DefaultAssay(scdata) <- "RNA"
         data.split <- Seurat::SplitObject(scdata, split.by = "samples")

--- a/qc-runner/src/init.r
+++ b/qc-runner/src/init.r
@@ -256,7 +256,7 @@ init <- function() {
             workerName = pipeline_config$pod_name
         )
 
-        if(!length(taskToken) || taskToken == "") {
+        if(is.null(taskToken) || !length(taskToken) || taskToken == "") {
             message('No input received during last poll, shutting down...')
             quit('no')
         }


### PR DESCRIPTION
# Background

In the process to migrate code from data-ingest to pipeline, gene dispersion was not calculated correctly.
Note, in order for this to work, the Seurat object needs `scdata@misc[["gene_annotations"]]` to be present, which should normally be added by data-ingest, but has been found to be absent for some data.

This code should fix this.

#### Link to issue 

#### Link to staging deployment URL 

https://ui-oliver-w99p35.scp-staging.biomage.net/experiments/e52b39624588791a7889e39c617f669e/data-exploration

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
