### PR TITLE
Dealing with too few cells in pipeline

### DIFF
--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -26,10 +26,11 @@
 #   },
 
 task <- function(scdata, config,task_name,sample_id){
+    # this options shows the callstack when an error is thrown
+    options(error = function() { traceback(2); if(!interactive()) quit("no", status = 1, runLast = FALSE) })
     # increase maxSize from the default of 500MB to 32GB
     # TODO: ask Marcell for his opinion
     options(future.globals.maxSize= 32 * 1024 * 1024^2)
-    
     # Check wheter the filter is set to true or false
     # So far we only support Seurat V3
     scdata.integrated <- run_dataIntegration(scdata, config)
@@ -39,7 +40,6 @@ task <- function(scdata, config,task_name,sample_id){
     # As a short solution, we are going to store an intermediate slot for the numPCs, since this parameter is required when performing
     # the computeEmdedding. The main reason to do not have in the config.configureEmbedding is that this parameter does not change in the configureEmbedding step.
     scdata.integrated@misc[["numPCs"]] <- config$dimensionalityReduction$numPCs
-
 
     scdata.integrated <- colorObject(scdata.integrated)
     cells_order <- rownames(scdata.integrated@meta.data)
@@ -96,6 +96,8 @@ run_dataIntegration <- function(scdata, config){
     # We require just to get an overview of the data-integration
     umap_min_distance <- 0.3
     umap_distance_metric <- "euclidean"
+    # default for FindIntegrationAnchors
+    k.filter <- 200 
 
     # temporary to make sure we don't run integration if unisample
     nsamples <- length(unique(scdata$samples))
@@ -109,12 +111,30 @@ run_dataIntegration <- function(scdata, config){
             data.split[[i]] <- Seurat::NormalizeData(data.split[[i]], normalization.method = normalization, verbose = F)
             data.split[[i]] <- Seurat::FindVariableFeatures(data.split[[i]], selection.method = "vst", nfeatures = nfeatures, verbose = FALSE)
         }
-        data.anchors <- Seurat::FindIntegrationAnchors(object.list = data.split, dims = 1:numPCs, verbose = FALSE)
+        # If Number of anchor cells is less than k.filter/2, there is likely to be an error:
+        # Note that this is a heuristic and was found to still fail for small data-sets
 
-        # @misc slots not preserved so transfer
-        misc <- scdata@misc
-        scdata <- Seurat::IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
-        scdata@misc <- misc
+        # Try to integrate data (catch error most likely caused by too few cells)
+        tryCatch(expression = {
+          k.filter <- min(ceiling(sapply(data.split, ncol)/2), k.filter)
+          data.anchors <- Seurat::FindIntegrationAnchors(object.list = data.split, dims = 1:numPCs, k.filter = k.filter, verbose = TRUE)
+
+          # @misc slots not preserved so transfer
+          misc <- scdata@misc
+          scdata <- Seurat::IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
+          scdata@misc <- misc
+        },
+        error = function(e){          # Specifying error message
+          # ideally this should be passed to the UI as a error message:
+          print(table(scdata$samples))
+          print(e)
+          print(paste("current k.filter:", k.filter))
+          # Should we still continue if data is not integrated? No, right now..
+          print("Current number of cells per sample: ")
+          print(table(scdata$samples))
+          stop("Error thrown in IntegrateData: Probably one/many of the samples contain to few cells.\nRule of thumb is that this can happen at around < 100 cells.")
+        })
+
         Seurat::DefaultAssay(scdata) <- "integrated"
     }else{
         print('Only one sample detected.')

--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -27,7 +27,7 @@
 
 task <- function(scdata, config,task_name,sample_id){
     # this options shows the callstack when an error is thrown
-    options(error = function() { traceback(2); if(!interactive()) quit("no", status = 1, runLast = FALSE) })
+    options(error = function() { traceback(3); if(!interactive()) quit("no", status = 1, runLast = FALSE) })
     # increase maxSize from the default of 500MB to 32GB
     # TODO: ask Marcell for his opinion
     options(future.globals.maxSize= 32 * 1024 * 1024^2)

--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -123,8 +123,8 @@ run_dataIntegration <- function(scdata, config){
           misc <- scdata@misc
           scdata <- Seurat::IntegrateData(anchorset = data.anchors, dims = 1:numPCs)
           scdata@misc <- misc
-        },
-        error = function(e){          # Specifying error message
+          Seurat::DefaultAssay(scdata) <- "integrated"
+        }, error = function(e){          # Specifying error message
           # ideally this should be passed to the UI as a error message:
           print(table(scdata$samples))
           print(e)
@@ -135,7 +135,6 @@ run_dataIntegration <- function(scdata, config){
           stop("Error thrown in IntegrateData: Probably one/many of the samples contain to few cells.\nRule of thumb is that this can happen at around < 100 cells.")
         })
 
-        Seurat::DefaultAssay(scdata) <- "integrated"
     }else{
         print('Only one sample detected.')
         # Else, we are in unisample experiment and we only need to normalize 

--- a/qc-runner/src/dataIntegration.r
+++ b/qc-runner/src/dataIntegration.r
@@ -115,7 +115,8 @@ run_dataIntegration <- function(scdata, config){
         # Note that this is a heuristic and was found to still fail for small data-sets
 
         # Try to integrate data (catch error most likely caused by too few cells)
-        tryCatch(expression = {
+
+        tryCatch({
           k.filter <- min(ceiling(sapply(data.split, ncol)/2), k.filter)
           data.anchors <- Seurat::FindIntegrationAnchors(object.list = data.split, dims = 1:numPCs, k.filter = k.filter, verbose = TRUE)
 


### PR DESCRIPTION
# Background

At the moment we are not handling the case in which the user overly-filters the dataset, leading to errors in those cases. This also applies to the case when all cells of one sample have been filtered, or even when all the cells of all samples - 1 have been filtered leading us to have a unisample from a seemingly multisample object. See this discussion for details:
https://this-is-biomage.slack.com/archives/C01CP46TJ0Z/p1619106701119000
# Goals

-Decide how to deal with overfiltered (empty or almost-empty) datasets

-Implement the required changes if on the pipeline, or create a ticket and coordinate with engineering the implementation from the UI.

After exploring and testing this issue I came to the following conclusion:
- It is hard to set fixed threshold to prevent users from over filtering since
- Some datasets are indeed of bad quality so sometimes it makes sense to filter out more
And we should not prevent the user from doing so by implementing hard thresholds, rather warn them.
- Nevertheless, there exists thresholds at which the pipeline does fail.
One of the steps is `Seurat::IntegrateData` which throws an error such as `Error in idx[i, ] <- res[[I]][[1]]`.
This is caused by insufficient number of cells. The actual number is hard to pin down and also depends on 
Other parameter such as `k.filter` used by the preparing `FindIntegrationAnchors` which sets how many neighbours cells are used to determine anchors. I've mitigated to adjust this parameter for low cell numbers, but this only goes so far as
About about `100` cells. A definite not working threshold is 30 (PCA dimensions) 

- After more consideration I think the best option is to have the warnings calculated and shown at at the UI side.
I.e. if a given filter has samples below a given threshold (i.e. 100) or if more than say 50% of cells are filtered. 
I'll write an engineering ticket to do so.

- we have to think about how to report errors and warnings back to the UI. I'll write an engineering ticket to do so. 

As for the filter themselves, 
- doublet filter is sometimes not bimodal and tends to filter a lot
  -> as a reminder, only about 5-10% of cells are expected to be doublets


#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-815

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
