### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ to save the arguments to all task functions:
 # e.g. DEBUG_STEP=dataIntegration
 DEBUG_STEP=task_name DEBUG_PATH=/path/to/debug/folder npm start
 ```
+Note: `DEBUG_PATH` needs to be an absolute path (rather than relative), i.e. being in `pipeline/local-runner` this can be used 
+to populate the local subfolder `mydebug`:
+
+```bash
+DEBUG_STEP=all DEBUG_PATH=${PWD}/mydebug npm restart
+```
 
 When the pipeline is run, it will save the arguments to the specified `task_name` in `DEBUG_PATH`. You
 can load these into your R environment:


### PR DESCRIPTION
pointing out the need for absolute path for `DEBUG_PATH`

# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
