### PR TITLE
Lost host address

### DIFF
--- a/local-runner/src/app.js
+++ b/local-runner/src/app.js
@@ -33,19 +33,22 @@ const initStack = async () => {
     region: 'eu-west-1',
   });
 
+  const stackName = {
+    StackName: 'local-container-launcher',
+  }; 
   try {
-    await cf.deleteStack({
-      StackName: 'local-container-launcher',
-    }).promise();
+    await cf.deleteStack(stackName).promise();
+    await cf.waitFor('stackDeleteComplete', stackName).promise();
   } catch (e) {
     console.log('No previous stack found on InfraMock.');
   }
 
   const { StackId } = await cf.createStack({
-    StackName: 'local-container-launcher',
+    ...stackName,
     Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
     TemplateBody: setVarsInTemplate(data),
   }).promise();
+  await cf.waitFor('stackCreateComplete', stackName).promise();
 
   console.log('Stack with ARN', StackId, 'successfully created.');
 };

--- a/qc-runner/src/init.r
+++ b/qc-runner/src/init.r
@@ -27,7 +27,10 @@ load_config <- function(development_aws_server) {
 
     # running in linux needs the IP of the host to work. If it is set as an environment variable (by makefile) honor it instead of the
     # provided parameter
-    development_aws_server = Sys.getenv("HOST_IP", development_aws_server)
+    overriden_server = Sys.getenv("HOST_IP", "")
+    if (overriden_server != "") {
+        development_aws_server = overriden_server
+    } 
     
     if(config$cluster_env == 'development') {
         config$aws_config[['endpoint']] <- sprintf("http://%s:4566", development_aws_server) # DOCKER_GATEWAY_HOST


### PR DESCRIPTION
# Background
#### Link to issue 
N/A
#### Link to staging deployment URL 
Issue in the local development environment
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

In our latest attempt to make life simpler for linux user, we broke the environment for MacOS users, overriding with an empty string `host.docker.internal`

# Changes
### Code changes

* Prevent the `host.docker.internal` override
* Wait for clouformation operations to complete before the next step

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
![Ugly Penguin](https://user-images.githubusercontent.com/460418/116758979-86f06700-aa11-11eb-9d52-29bba199d219.jpeg)
