### PR TITLE
handle NA doublet scores

### DIFF
--- a/qc-runner/src/doubletScores.r
+++ b/qc-runner/src/doubletScores.r
@@ -69,7 +69,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
         # extract cell id that do not(!) belong to current sample (to not apply filter there)
         barcode_names_non_sample <- rownames(obj_metadata[-grep(tmp_sample, rownames(obj_metadata)),]) 
         # all barcodes that match threshold in the subset data
-        barcode_names_keep_current_sample <-rownames(sample_subset@meta.data[sample_subset$doublet_scores <= probabilityThreshold,])
+        barcode_names_keep_current_sample <-rownames(sample_subset@meta.data[which(sample_subset$doublet_scores <= probabilityThreshold),])
         # combine the 2:
         barcodes_to_keep <- union(barcode_names_non_sample, barcode_names_keep_current_sample)
         # Information regarding doublet score is pre-computed during the 'data-ingest'. 


### PR DESCRIPTION
We can have NA `doublet_scores` as they are only calculated on non-empty droplets (`ed.out$FDR < 0.001`). This commit handles NA's:

![image](https://user-images.githubusercontent.com/15719520/117716747-d3b10c00-b18e-11eb-91be-8c4e4649b112.png)
