### PR TITLE
Display the command used to launch docker from lambda

### DIFF
--- a/local-runner/cf-local-container-launcher.yaml
+++ b/local-runner/cf-local-container-launcher.yaml
@@ -39,12 +39,12 @@ Resources:
               f"-v __DEBUG_PATH__:/debug",
               event['image']
             ])
-
+            subprocess.run(f"echo {docker_command}", shell=True, check=True)
             proc = subprocess.run(docker_command, shell=True, check=True)
 
             return proc.returncode
       Runtime: "python3.8"
-      Timeout: "25"
+      Timeout: 25
   QualityControlActivity:
     Type: AWS::StepFunctions::Activity
     Properties: 
@@ -65,4 +65,4 @@ Resources:
 
             return proc.returncode
       Runtime: "python3.8"
-      Timeout: "25"
+      Timeout: 25


### PR DESCRIPTION
Minor changes.

* echo the docker command launched by lambda functions in local development
* set lambda timeout as an integer rather than as a string https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-timeout