### PR TITLE
fix per sample custom config

### DIFF
--- a/pipeline-runner/src/data-ingest/4_Prepare_experiment.r
+++ b/pipeline-runner/src/data-ingest/4_Prepare_experiment.r
@@ -104,7 +104,7 @@ add_custom_config_per_sample <- function(step_fn, config, scdata){
 
   samples <- seurat_obj$samples
   
-  for(sample in samples){
+  for(sample in unique(samples)){
     # Downsample the seurat object to a unisample experiment
     scdata_sample <- scdata[, samples %in% sample]
     # Run the step fun with the unisample experiment and keep the config result

--- a/pipeline-runner/src/data-ingest/4_Prepare_experiment.r
+++ b/pipeline-runner/src/data-ingest/4_Prepare_experiment.r
@@ -97,14 +97,16 @@ numGenesVsNumUmis_config <- function(scdata, config){
 #                 }
 # }
 
-add_custom_config_per_sample <- function(step_fn, config, scdata, samples){
+add_custom_config_per_sample <- function(step_fn, config, scdata){
   
   # We upadte the config file, so to be able to access the raw config we create a copy
   config.raw <- config
+
+  samples <- seurat_obj$samples
   
   for(sample in samples){
     # Downsample the seurat object to a unisample experiment
-    scdata_sample <- subset(scdata, samples %in% sample)
+    scdata_sample <- scdata[, samples %in% sample]
     # Run the step fun with the unisample experiment and keep the config result
     result_config <- step_fn(scdata_sample, config.raw)
     # Inside the config of the samples we are not storing the auto and enable settings, so we remove them
@@ -371,9 +373,9 @@ task <- function(input,pipeline_config){
     )
 
     # Compute for multisample and unisample
-    config.cellSizeDistribution <- add_custom_config_per_sample(cellSizeDistribution_config, config.cellSizeDistribution, seurat_obj, unique(seurat_obj$samples))
-    config.numGenesVsNumUmis <- add_custom_config_per_sample(numGenesVsNumUmis_config, config.numGenesVsNumUmis, seurat_obj, unique(seurat_obj$samples))
-    config.doubletScores <- add_custom_config_per_sample(doubletScores_config, config.doubletScores, seurat_obj, unique(seurat_obj$samples))
+    config.cellSizeDistribution <- add_custom_config_per_sample(cellSizeDistribution_config, config.cellSizeDistribution, seurat_obj)
+    config.numGenesVsNumUmis <- add_custom_config_per_sample(numGenesVsNumUmis_config, config.numGenesVsNumUmis, seurat_obj)
+    config.doubletScores <- add_custom_config_per_sample(doubletScores_config, config.doubletScores, seurat_obj)
 
     # When we remove the steps from data-ingest we need to change here the default config. 
     # Save config for all steps. 


### PR DESCRIPTION
# Linked Issue

Also fixed in data-ingest: https://github.com/biomage-ltd/data-ingest/pull/34

# Background

The function `add_custom_config_per_sample` wasn't subsetting the dataset. This created a bug where the entire object was being used to calculate default cellSizeDistribution, numGenesVsNumUmis and doubletScore thresholds. For example all the doubletScore thresholds end up the same:

![image](https://user-images.githubusercontent.com/15719520/119414401-5dd79500-bca4-11eb-805a-89656b9f5f8f.png)

This is the same value as if I calculate the threshold with the full seurat object:

![image](https://user-images.githubusercontent.com/15719520/119414594-b0b14c80-bca4-11eb-8877-69ef099443b3.png)

Whereas e.g. for an actual sample subset we get something different for each sample:

![image](https://user-images.githubusercontent.com/15719520/119414718-eeae7080-bca4-11eb-9c28-e61253e8f9d3.png)
