### PR TITLE
port doublet score code from data-ingest

### DIFF
--- a/pipeline-runner/src/data-ingest/2-2_Compute-metrics_doublets.r
+++ b/pipeline-runner/src/data-ingest/2-2_Compute-metrics_doublets.r
@@ -10,14 +10,24 @@
 #' @param sample_name Name of the sample that we are preparing.
 #'
 #' @return 
-compute_doublet_scores <- function(scdata, sample_name, min.features = 10) {
+compute_doublet_scores <- function(scdata, sample_name) {
     message("loading scd")
     library(scDblFinder)
     message("loaded")
     message("Sample --> ", sample_name, "...")
-    scdata_DS <- scDblFinder::scDblFinder(scdata[, Matrix::colSums(scdata>0)>=min.features], dbr = NULL, trajectoryMode = FALSE)
-    df_doublet_scores <- data.frame(Barcodes=rownames(scdata_DS@colData), doublet_scores=scdata_DS@colData$scDblFinder.score,
-    doublet_class = scdata_DS@colData$scDblFinder.class)
+
+
+    edpath <- paste0("/output/pre-emptydrops-", sample_name, ".rds")
+    if (file.exists(edpath)) {
+        edout <- readRDS(edpath)
+        keep <- which(edout$FDR <= 0.001)
+        scdata <- scdata[, keep]
+    }
+
+    scdata_DS <- scDblFinder(scdata, dbr = NULL, trajectoryMode = FALSE)
+    df_doublet_scores <- data.frame(Barcodes = rownames(scdata_DS@colData),
+                                    doublet_scores = scdata_DS@colData$scDblFinder.score,
+                                    doublet_class = scdata_DS@colData$scDblFinder.class)
 
     write.table(df_doublet_scores, file = paste("/output/doublet-scores-", sample_name, ".csv", sep = ""), row.names = FALSE, col.names = FALSE, quote = FALSE, sep = "\t")
 }


### PR DESCRIPTION
# Background

scDblFinder is the current bottleneck in GEM2S. This should be faster and also prevent errors from asking for doublet scores when there are lots of empty droplets in the matrix.

Staging link:
https://ui-oliver-p78.scp-staging.biomage.net/
https://ui-mvpdev.scp-staging.biomage.net/