### PR TITLE
new flow for releases

### DIFF
--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -1,0 +1,49 @@
+name: Create a new release
+
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version you want to release.'
+        required: true
+
+jobs:
+  create-release:
+    name: ${{ format('Create release {0}', github.event.inputs.repo) }}
+    runs-on: ubuntu-20.04
+    steps:
+
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - id: create-release
+        name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+        
+      - id: initialize-git-info
+        name: Initialize mandatory git info
+        run: git config user.name "Github Actions"
+      
+      - id: push-release
+        name: Push new release branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - id: create-pr
+        name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: master
+          title: Release version ${{ github.event.inputs.version }}
+          body: |
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            
+            This release candidate should be staged in :
+            https://ui-${{ github.event.inputs.version }}.scp-staging.biomage.net/
+
+            Merging this PR will create a GitHub release, update master & develop branches, and upload any assets that are created as part of the release build.

--- a/.github/workflows/prevent-pr-to-master.yaml
+++ b/.github/workflows/prevent-pr-to-master.yaml
@@ -8,10 +8,11 @@ on:
 jobs:
   run:
     runs-on: ubuntu-20.04
+    if: (!startsWith(github.event.pull_request.head.ref, 'release/') && !startsWith(github.event.pull_request.head.ref, 'hotfix/')) # allow PRs to master for releases & hotfixes
     steps:
     - uses: superbrothers/close-pull-request@v2
       with:
         comment: |-
-            Pull requests to master are not allowed, merge into develop.
+            Pull requests to master are not allowed unless they are releases or hotfixes, merge into develop.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yaml
+++ b/.github/workflows/publish-new-release.yaml
@@ -1,0 +1,55 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Publish new release
+    runs-on: ubuntu-20.04
+    # only trigger on merged pull requests named release/* or hotfix/*
+    if: |
+        github.event.pull_request.merged == true && 
+        (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/')) 
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from branch name (for hotfix branches)
+        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#hotfix/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create Release
+        uses: thomaseizinger/create-release@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
+
+      - name: Merge master into dev branch
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: master
+          base: develop
+          title: Merge master into dev branch
+          body: |
+            This PR merges the master branch back into develop.


### PR DESCRIPTION
Create new github actions for release style.

Now we'll have a `draft release` button which will create a new release branch called `release/version` & PR.

Once that branch is tested, merging it will trigger the new release, creating a tag, merging into master and creating PR to merge into develop.

The new flow also supports creating branches called hotfix/* to merge into master directly.

