### PR TITLE
added deployment for release/hotfixes PRs to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,15 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-docker:
     name: Build Docker container
     runs-on: ubuntu-20.04
+    if: startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/') # allow PRs to master for releases & hotfixes
     strategy:
       matrix:
         project: ['pipeline-runner']


### PR DESCRIPTION
As PRs to master were not allowed, the new release PRs are not being built. Allow them to be built only for branches names `release/*` or `hotfix/*`.