### PR TITLE
Fix determination of HOST_IP on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 # to be picked up by the R worker.
 # See README.md/Running on Docker issues, for more info
 ifneq ($(shell uname -s), Darwin)
-	export HOST_IP=$(shell hostname -I | awk '{print $$1}')
+    # Get the gateway address of the default bridge network
+	export HOST_IP=$(shell docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
 endif
 #--------------------------------------------------
 # Targets

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # to be picked up by the R worker.
 # See README.md/Running on Docker issues, for more info
 ifneq ($(shell uname -s), Darwin)
-    # Get the gateway address of the default bridge network
+	# Get the gateway address of the default bridge network
 	export HOST_IP=$(shell docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
 endif
 #--------------------------------------------------


### PR DESCRIPTION
# Background

On Linux the `HOST_IP` variable needs to be set manually. Previously this was done with `hostname -I`. This was unreliable as a) not all versions of hostname have this option and b) the output order [is not guaranteed](https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x#comment40729437_25851186). Instead, we get the address of Docker's bridge network directly using `docker config`.

[Credit for the new command goes here.](https://stackoverflow.com/a/55224655/7799676)

# Changes
### Code changes
Changed how `HOST_IP` is set on Linux in `Makefile`

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
