### PR TITLE
hardcode DEBUG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make build
  access it later from `$(pwd)/debug`.
 
 To save the parameters (`config`, `seurat_obj`, etc) to a data processing task function, specify DEBUG_STEP.
-Available tasks include all those defined in `run_step` of  [init.r](pipeline-runner/src/init.r#L72) as well as `DEBUG_STEP=all` 
+Available tasks include all those defined in `run_processing_step` of  [init.r](pipeline-runner/src/init.r#L72) as well as `DEBUG_STEP=all` 
 to save the parameters to all data processing task functions:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -47,25 +47,28 @@ make build
 ```
 
 ## Debugging locally
-To save the parameters (`config`, `seurat_obj`, etc) to a task function, specify DEBUG_STEP and DEBUG_PATH.
-Available tasks include all those defined in `run_step` of  [init.r](pipeline-runner/src/init.r) as well as `DEBUG_STEP=all` 
-to save the parameters to all task functions:
+
+**TLDR**: save something inside `/debug` in a data processing or gem2s step to
+ access it later from `$(pwd)/debug`.
+
+To save the parameters (`config`, `seurat_obj`, etc) to a data processing task function, specify DEBUG_STEP.
+Available tasks include all those defined in `run_step` of  [init.r](pipeline-runner/src/init.r#L72) as well as `DEBUG_STEP=all` 
+to save the parameters to all data processing task functions:
 
 ```bash
 # e.g. DEBUG_STEP=dataIntegration
-DEBUG_STEP=task_name DEBUG_PATH=${PWD}/mydebug make run
+DEBUG_STEP=task_name make run
 ```
-Note: `DEBUG_PATH` needs to be an absolute path. The above can be used to populate the local subfolder `mydebug`.
 
-When the pipeline is run, it will save the parameters to the specified `task_name` in `DEBUG_PATH`. You
+When the pipeline is run, it will save the parameters to the specified `task_name` in `$(pwd)/debug`. You
 can load these into your R environment:
 
 ```R
 # clicking the file in RStudio does this for you
-load('/path/to/debug/folder/{task_name}_{sample_id}.RData')
+load('{task_name}_{sample_id}.RData')
 
 # if you need to load multiple tasks, you can load each into a seperate environment
 # you would when access objects using e.g. task_env$scdata
 task_env <- new.env()
-load('/path/to/debug/folder/{task_name}_{sample_id}.RData', envir = task_env)
+load('{task_name}_{sample_id}.RData', envir = task_env)
 ```

--- a/local-runner/package.json
+++ b/local-runner/package.json
@@ -10,7 +10,7 @@
     "coverage": "jest --coverage --silent",
     "dev": "nodemon src/app.js",
     "build": "docker build -t biomage-pipeline-runner ../pipeline-runner",
-    "start": "node src/app.js",
+    "start": "DEBUG_PATH=$(pwd)/debug node src/app.js",
     "restart": "npm run build && npm start",
     "lint": "eslint ./src",
     "detect-secrets": "pip3 install detect-secrets && git diff --staged --name-only | xargs detect-secrets-hook --baseline .secrets.baseline"


### PR DESCRIPTION
# Background
I updated my docker and it doesn't seem to like unset host part on volume anymore:

![image](https://user-images.githubusercontent.com/15719520/121091488-e96e1d00-c79e-11eb-9c40-98733156f9fa.png)

To resolve I've hardcoded the `DEBUG_PATH=$(pwd)/debug`. In addition to fixing this issue it also simplifies debug specification and always exposes a host path where it's possible to save something that will be available outside of the container. 

This provides a nice use patern that I find myself using: instead of specifying a DEBUG_STEP, you can just save something in `/debug`. I have used this for gem2s debugging where the DEBUG_STEP is not set up.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
