### PR TITLE
switch from orig.ident to samples

### DIFF
--- a/pipeline-runner/src/cellSizeDistribution.r
+++ b/pipeline-runner/src/cellSizeDistribution.r
@@ -33,17 +33,17 @@ generate_default_values_cellSizeDistribution <- function(seurat_obj, config, thr
   seurat_obj_tmp <- CalculateBarcodeInflections(
     object = seurat_obj,
     barcode.column = "nCount_RNA",
-    group.column = "orig.ident",
+    group.column = "samples",
     # [HARDCODED]
     threshold.low = threshold.low,
     threshold.high = NULL
   )
   # extracting the inflection point value which can serve as minCellSize threshold
   # all other side effects to the scdate object will be discarded
-  # [TODO unittest]: this calculation assumes a single sample, i.e. only one group in orig.ident!
+  # [TODO unittest]: this calculation assumes a single sample, i.e. only one group in samples!
   # otherwise it will return multiple values for each group!
   # returned is both the rank(s) as well as inflection point
-  # orig.ident          nCount_RNA  rank
+  # samples          nCount_RNA  rank
   # SeuratProject       1106        10722
   sample_subset <- Tool(seurat_obj_tmp, slot = "CalculateBarcodeInflections")$inflection_points
   # extracting only inflection point(s)
@@ -55,7 +55,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     print("Config:")
     print(config)
     print(paste0("Cells per sample before filter for sample ", sample_id))
-    print(table(seurat_obj$orig.ident))
+    print(table(seurat_obj$samples))
     #The format of the sample_id is
     # sample-WT1
     # we need to get only the last part, in order to grep the object.
@@ -139,7 +139,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     }
 
     print(paste0("Cells per sample after filter for sample ", sample_id))
-    print(table(seurat_obj.filtered$orig.ident))
+    print(table(seurat_obj.filtered$samples))
 
     # update config
     config$filterSettings$minCellSize <- minCellSize

--- a/pipeline-runner/src/classifier.r
+++ b/pipeline-runner/src/classifier.r
@@ -60,7 +60,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
   print(config)
   print(paste0("Cells per sample before filter for sample ", sample_id))
   
-  print(table(seurat_obj$orig.ident, useNA="ifany"))
+  print(table(seurat_obj$samples, useNA="ifany"))
   #The format of the sample_id is
   # sample-WT1
   # we need to get only the last part, in order to grep the object.
@@ -100,7 +100,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
       }
       sample_subset <- subset(seurat_obj, cells = barcode_names_this_sample)
       print("Info: empty-drops table of FDR threshold categories (# UMIs for a given threshold interval")
-      print(table(obj_metadata$orig.ident, cut(obj_metadata$emptyDrops_FDR, breaks = c(-Inf,0,0.0001,0.01,0.1,0.5,1,Inf)), useNA="ifany"))
+      print(table(obj_metadata$samples, cut(obj_metadata$emptyDrops_FDR, breaks = c(-Inf,0,0.0001,0.01,0.1,0.5,1,Inf)), useNA="ifany"))
       
       # prevents filtering of NA FDRs if FDR=1
       ed_fdr <- sample_subset$emptyDrops_FDR
@@ -144,7 +144,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     seurat_obj <- seurat_obj
   }
   print(paste0("Cells per sample after filter for sample ", sample_id))
-  print(table(seurat_obj$orig.ident, useNA="ifany"))
+  print(table(seurat_obj$samples, useNA="ifany"))
   # > head(guidata[[1]])
   # [[1]]
   # FDR    log_u

--- a/pipeline-runner/src/data-ingest/test_object.r
+++ b/pipeline-runner/src/data-ingest/test_object.r
@@ -15,7 +15,7 @@ test_object <- function(scdata){
         expect_true(nrow(scdata@meta.data) == ncol(scdata))
         md <- scdata@meta.data
         expect_true("barcode" %in% colnames(md))
-        expect_true("orig.ident" %in% colnames(md))  
+        expect_true("samples" %in% colnames(md))  
         if(any(grepl("^mt-", annotations$name, ignore.case = T))){
             expect_true("percent.mt" %in% colnames(md))
         }

--- a/pipeline-runner/src/doubletScores.r
+++ b/pipeline-runner/src/doubletScores.r
@@ -33,7 +33,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     print("Config:")
     print(config)
     print(paste0("Cells per sample before filter for sample ", sample_id))
-    print(table(seurat_obj$orig.ident))
+    print(table(seurat_obj$samples))
     #The format of the sample_id is
     # sample-WT1
     # we need to get only the last part, in order to grep the object.
@@ -104,7 +104,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     guidata[generate_gui_uuid(sample_id, task_name, 0)] <- list(plot1_data)
     
     print(paste0("Cells per sample after filter for sample ", sample_id))
-    print(table(seurat_obj.filtered$orig.ident))
+    print(table(seurat_obj.filtered$samples))
     
     # populate with filter statistics
     filter_stats <- list(

--- a/pipeline-runner/src/mitochondrialContent.r
+++ b/pipeline-runner/src/mitochondrialContent.r
@@ -38,7 +38,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     print("Config:")
     print(config)
     print(paste0("Cells per sample before filter for sample ", sample_id))
-    print(table(seurat_obj$orig.ident))
+    print(table(seurat_obj$samples))
     tmp_sample <- sub("sample-","",sample_id)
     # Check if the experiment has MT-content
     if (!"percent.mt"%in%colnames(seurat_obj@meta.data)){
@@ -116,7 +116,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
 
     # some tests:
     print(paste0("Cells per sample after filter for sample ", sample_id))
-    print(table(seurat_obj.filtered$orig.ident))
+    print(table(seurat_obj.filtered$samples))
     
     # populate with filter statistics
     filter_stats <- list(

--- a/pipeline-runner/src/numGenesVsNumUmis.r
+++ b/pipeline-runner/src/numGenesVsNumUmis.r
@@ -40,7 +40,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     print("Config:")
     print(config)
     print(paste0("Cells per sample before filter for sample ", sample_id))
-    print(table(seurat_obj$orig.ident))
+    print(table(seurat_obj$samples))
     #The format of the sample_id is
     # sample-WT1
     # we need to get only the last part, in order to grep the object.
@@ -121,7 +121,7 @@ task <- function(seurat_obj, config, task_name, sample_id, num_cells_to_downsamp
     guidata[generate_gui_uuid(sample_id, task_name, 0)] <- list(plot1_data)
 
     print(paste0("Cells per sample after filter for sample ", sample_id))
-    print(table(seurat_obj.filtered$orig.ident))
+    print(table(seurat_obj.filtered$samples))
     
     # Populate with filter statistics
     filter_stats <- list(


### PR DESCRIPTION
# Background
#### Link to issue 
[BIOMAGE-967](https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-967)

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

This also fixes a bug for the knee plot: it was not previously calculating the knee per sample as it was using `orig.ident` for grouping

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
