### PR TITLE
added r.utils dependency install which is required by seurat-wrappers

### DIFF
--- a/pipeline-runner/Dockerfile
+++ b/pipeline-runner/Dockerfile
@@ -27,6 +27,7 @@ RUN R -e 'pak::pkg_install("Seurat")'
 RUN R -e 'pak::pkg_install("gprofiler2")'
 RUN R -e 'pak::pkg_install("sccore")'
 RUN R -e 'pak::pkg_install("GO.db")'
+RUN R -e 'pak::pkg_install("R.utils")'
 RUN R -e 'pak::pkg_install("satijalab/seurat-wrappers")'
 RUN R -e 'pak::pkg_install("batchelor")'
 


### PR DESCRIPTION
Docker build is failing due to changes in `seurat-wrappers` which now require `R.utils` to be installed.

https://github.com/biomage-ltd/pipeline/runs/2821632997?check_suite_focus=true#step:9:4390