### PR TITLE
allow special chars in metadata

### DIFF
--- a/pipeline-runner/R/gem2s-helpers.R
+++ b/pipeline-runner/R/gem2s-helpers.R
@@ -35,7 +35,7 @@ check_config <- function(scdata, sample, config) {
   # Check if "metadata" exists on config. If it is TRUE, we have other metadata information that we are
   # going to include in our experiment.
   if ("metadata" %in% names(config)) {
-    rest_metadata <- as.data.frame(config$metadata)
+    rest_metadata <- as.data.frame(config$metadata, check.names = FALSE)
     rest_metadata$sample <- config$samples
     for (var in colnames(rest_metadata)) {
       metadata[, var] <- rest_metadata[, var][match(metadata$sample, rest_metadata$sample)]


### PR DESCRIPTION
# Background
See [slack thread](https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1624611727102300)

This allows specials characters in metadata column names:

```R
# before
as.data.frame(list('a-b'=1, 'a b'=1, '1ab'=1, '😍'=1))
  a.b a.b.1 X1ab X.
1   1     1    1  1

# after
as.data.frame(list('a-b'=1, 'a b'=1, '1ab'=1, '😍'=1), check.names = FALSE)
  a-b a b 1ab 😍
1   1   1   1  1
```

