### PR TITLE
Move defaultFilterSettings and missing per sample config additions to the pipeline

### DIFF
--- a/pipeline-runner/R/gem2s-6-prepare_experiment.R
+++ b/pipeline-runner/R/gem2s-6-prepare_experiment.R
@@ -304,9 +304,6 @@ numGenesVsNumUmis_config <- function(scdata, config) {
 # }
 
 duplicate_config_per_sample <- function(step_config, config, samples) {
-  # # We upadte the config file, so to be able to access the raw config we create a copy
-  # config.raw <- config
-
   for (sample in unique(samples)) {
     config[[sample]] <- step_config
     config[[sample]]$defaultFilterSettings <- step_config$filterSettings


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-api172-pipelin.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/api/pull/172

#### Anything else the reviewers should know about the changes here
The api was performing the changes added in the PR, there seemed to be some inconsistent behavior on the api in staging for this so I decided to move it over to the pipeline now in order to avoid potential bugs (which was already the plan in the long run).

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
