### PR TITLE
Upload count matrix with multipart upload

### DIFF
--- a/pipeline-runner/R/handle_data.R
+++ b/pipeline-runner/R/handle_data.R
@@ -145,19 +145,16 @@ send_plot_data_to_s3 <- function(pipeline_config, experiment_id, output) {
 }
 
 upload_matrix_to_s3 <- function(pipeline_config, experiment_id, data) {
-  s3 <- paws::s3(config = pipeline_config$aws_config)
 
   object_key <- paste0(experiment_id, "/r.rds")
 
   count_matrix <- tempfile()
   saveRDS(data, file = count_matrix)
 
+  message("Count matrix file size : ", format(object.size(count_matrix)))
   message("Uploading updated count matrix to S3 bucket ", pipeline_config$processed_bucket, " at key ", object_key, "...")
-  s3$put_object(
-    Bucket = pipeline_config$processed_bucket,
-    Key = object_key,
-    Body = count_matrix
-  )
+
+  put_object_in_s3_multipart(pipeline_config, pipeline_config$processed_bucket, count_matrix, object_key)
 
   return(object_key)
 }

--- a/pipeline-runner/codecov.yaml
+++ b/pipeline-runner/codecov.yaml
@@ -14,6 +14,4 @@ coverage:
         # this allows a 5% drop from the previous base commit coverage
         threshold: 3%
 
-    patch:                    # measuring the coverage of new changes
-      default:
-        enabled: no
+    patch: no                   # measuring the coverage of new changes

--- a/pipeline-runner/codecov.yaml
+++ b/pipeline-runner/codecov.yaml
@@ -14,4 +14,4 @@ coverage:
         # this allows a 5% drop from the previous base commit coverage
         threshold: 3%
 
-    patch: no                   # measuring the coverage of new changes
+    patch: off                   # measuring the coverage of new changes

--- a/pipeline-runner/codecov.yml
+++ b/pipeline-runner/codecov.yml
@@ -14,4 +14,4 @@ coverage:
         # this allows a 5% drop from the previous base commit coverage
         threshold: 3%
 
-    patch: off                 # measuring the coverage of new changes
+    patch: false                 # measuring the coverage of new changes

--- a/pipeline-runner/codecov.yml
+++ b/pipeline-runner/codecov.yml
@@ -14,6 +14,4 @@ coverage:
         # this allows a 5% drop from the previous base commit coverage
         threshold: 3%
 
-    patch:                      # measuring the coverage of new changes
-      default:
-        enabled: no
+    patch: off                 # measuring the coverage of new changes

--- a/pipeline-runner/codecov.yml
+++ b/pipeline-runner/codecov.yml
@@ -14,4 +14,6 @@ coverage:
         # this allows a 5% drop from the previous base commit coverage
         threshold: 3%
 
-    patch: off                   # measuring the coverage of new changes
+    patch:                      # measuring the coverage of new changes
+      default:
+        enabled: no


### PR DESCRIPTION
# Background
#### Link to issue 

https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1628765252019300

#### Link to staging deployment URL 

In API repo

#### Links to any Pull Requests related to this

API - https://github.com/biomage-ltd/api/pull/201

#### Anything else the reviewers should know about the changes here

- Changed upload count matrix method to use multipart upload

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
