### PR TITLE
add response.error to gem2s response

### DIFF
--- a/pipeline-runner/R/handle_data.R
+++ b/pipeline-runner/R/handle_data.R
@@ -66,7 +66,15 @@ send_gem2s_update_to_api <- function(pipeline_config, experiment_id, task_name, 
   message("Sending to SNS topic ", pipeline_config$sns_topic)
   sns <- paws::sns(config = pipeline_config$aws_config)
 
-  msg <- c(data, taskName = list(task_name), experimentId = list(experiment_id))
+  # Right now data is an empty list
+  msg <- list(
+    data = data,
+    taskName = task_name,
+    experimentId = experiment_id,
+    response = list(
+      error = FALSE
+    )
+  )
 
   result <- sns$publish(
     Message = RJSONIO::toJSON(msg),


### PR DESCRIPTION
# Background
#### Link to issue 

GEM2S reponse does not contain `response.error` in the response body, while QC response does. This PR adds that. Tthe property is used to check if there are errors in the step.

#### Link to staging deployment URL 

In API PR

#### Links to any Pull Requests related to this

API - https://github.com/biomage-ltd/api/pull/209
Pipeline - https://github.com/biomage-ltd/pipeline/pull/144

#### Anything else the reviewers should know about the changes here

- Add `response.error` to QC pipeline error.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
