### PR TITLE
Fix `glob:` doubling causing wrong images to be staged for environments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,7 +212,7 @@ jobs:
             KUBERNETES_ENV="production"
             REPLICA_COUNT="4"
             SHORT_TAG_REF=${REF_DASHED/refs-tags-/}
-            IMAGE_GLOB="glob:${IMAGE_TAG/$SHORT_TAG_REF/*}"
+            IMAGE_GLOB="${IMAGE_TAG/$SHORT_TAG_REF/*}"
             MEMORY_REQUEST="29Gi"
           fi
 
@@ -221,7 +221,7 @@ jobs:
             CHART_REF="$GITHUB_SHA"
             KUBERNETES_ENV="staging"
             REPLICA_COUNT="2"
-            IMAGE_GLOB="glob:${IMAGE_TAG/$GITHUB_SHA/*}"
+            IMAGE_GLOB="${IMAGE_TAG/$GITHUB_SHA/*}"
             MEMORY_REQUEST="29Gi"
           fi
 
@@ -230,7 +230,7 @@ jobs:
             CHART_REF="STAGING_CHART_REF"
             KUBERNETES_ENV="staging"
             REPLICA_COUNT="2"
-            IMAGE_GLOB="glob:${IMAGE_TAG/$GITHUB_SHA/*}"
+            IMAGE_GLOB="${IMAGE_TAG/$GITHUB_SHA/*}"
             MEMORY_REQUEST="4Gi"
           fi
 


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
