### PR TITLE
relax code coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,16 +2,16 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  range: 20..100
+  range: 40..100
   round: down
   precision: 2
 
   status:
     project:                   # measuring the overall project coverage
-      default:                 
+      default:
         target: auto
-        # don't allow new commits to decrease coverage
-        threshold: 0%
+        # allow new commits to decrease coverage
+        threshold: 4%
 
 
     patch: false                 # measuring the coverage of new changes


### PR DESCRIPTION
With current settings, a PR that reduces the number of lines will fail. For example (3 lines less, 3 fewer hits, so fail?): 

![Screenshot from 2021-09-22 19-14-04](https://user-images.githubusercontent.com/15719520/134445517-120a5e6a-5df1-42a4-b744-0fe5482d0ad1.png)


