### PR TITLE
[BIOMAGE-1427] Fix the config difference for staging and production services

### DIFF
--- a/pipeline-runner/init.R
+++ b/pipeline-runner/init.R
@@ -66,11 +66,6 @@ load_config <- function(development_aws_server) {
         )
     )
 
-    # temporary fix, in the future it would be good to unify the api app names for production / staging
-    if(config$cluster_env == 'production') {
-        config$api_url <- paste0("http://api.api-",sandbox,".svc.cluster.local:3000")
-    }
-
     config[["aws_config"]] <- list(region = config$aws_region)
 
     # running in linux needs the IP of the host to work. If it is set as an environment variable (by makefile) honor it instead of the


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1427

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/iac/pull/176

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
After the fix in https://github.com/biomage-ltd/iac/pull/176, this ensures that service names do not have to be specifically adjusted for production.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
