### PR TITLE
use HOST_IP for api url

### DIFF
--- a/pipeline-runner/init.R
+++ b/pipeline-runner/init.R
@@ -76,7 +76,7 @@ load_config <- function(development_aws_server) {
     }
 
     if(config$cluster_env == 'development') {
-        config$api_url <- "http://host.docker.internal:3000"
+        config$api_url <- sprintf("http://%s:3000", development_aws_server)
         config$aws_config[['endpoint']] <- sprintf("http://%s:4566", development_aws_server) # DOCKER_GATEWAY_HOST
         config$aws_config[['credentials']] <- list(
             creds = list(


### PR DESCRIPTION
# Background
`host.docker.internal` doesn't exist for linux. This uses `HOST_IP` for linux as set in the makefile.


Staging link

https://ui-olivergibson-pipeline170.scp-staging.biomage.net/